### PR TITLE
Fix Incorrect Declaration of C_WrapKeyAuthenticated

### DIFF
--- a/public-domain/3.2/pkcs11.h
+++ b/public-domain/3.2/pkcs11.h
@@ -2291,7 +2291,7 @@ extern CK_RV C_AsyncJoin(CK_SESSION_HANDLE, CK_UTF8CHAR *, CK_ULONG, CK_BYTE *,
                          CK_ULONG);
 extern CK_RV C_WrapKeyAuthenticated(CK_SESSION_HANDLE, CK_MECHANISM *,
                                     CK_OBJECT_HANDLE, CK_OBJECT_HANDLE,
-                                    CK_BYTE *, CK_ULONG *, CK_BYTE *,
+                                    CK_BYTE *, CK_ULONG, CK_BYTE *,
                                     CK_ULONG *);
 extern CK_RV C_UnwrapKeyAuthenticated(CK_SESSION_HANDLE, CK_MECHANISM *,
                                       CK_OBJECT_HANDLE, CK_BYTE *,
@@ -2483,7 +2483,7 @@ typedef CK_RV (* CK_C_AsyncJoin)(CK_SESSION_HANDLE, CK_UTF8CHAR *, CK_ULONG,
                                  CK_BYTE *, CK_ULONG);
 typedef CK_RV (* CK_C_WrapKeyAuthenticated)(CK_SESSION_HANDLE, CK_MECHANISM *,
                                             CK_OBJECT_HANDLE, CK_OBJECT_HANDLE,
-                                            CK_BYTE *, CK_ULONG *, CK_BYTE *,
+                                            CK_BYTE *, CK_ULONG, CK_BYTE *,
                                             CK_ULONG *);
 typedef CK_RV (* CK_C_UnwrapKeyAuthenticated)(CK_SESSION_HANDLE, CK_MECHANISM *,
                                               CK_OBJECT_HANDLE, CK_BYTE *,


### PR DESCRIPTION
Fixes a minor issue with the new  C_WrapKeyAuthenticated interface in the public domain v3.2 header. The associated data length (`ulAssociatedDataLen`) was accidentally defined as a pointer, but it needs to be a plain ULONG.

From _PKCS \#11 v3.2-wd13 - Section 5.18.6_:
```c
CK_DECLARE_FUNCTION(CK_RV, C_WrapKeyAuthenticated)(
    CK_SESSION_HANDLE hSession,
    CK_MECHANISM_PTR pMechanism,
    CK_OBJECT_HANDLE hWrappingKey,
    CK_OBJECT_HANDLE hKey,
    CK_BYTE_PTR pAssociatedData,
    CK_ULONG ulAssociatedDataLen,
    CK_BYTE_PTR pWrappedKey,
    CK_ULONG_PTR pulWrappedKeyLen
);
```

Btw. big thanks for your work 😉 We consider using your public domain headers for the PKCS \#11 wrapper of the Botan Crypto Library (https://github.com/randombit/botan/pull/4540). 